### PR TITLE
Update CMake minimum version and modernize iterator implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(littl)
 
 set(library ${PROJECT_NAME})

--- a/littl/List.hpp
+++ b/littl/List.hpp
@@ -90,8 +90,16 @@ namespace li
             };
 
             template <typename TT, typename This>
-            class generic_iterator : public std::iterator<std::input_iterator_tag, TT>
+            class generic_iterator
             {
+            public:
+                using iterator_category = std::input_iterator_tag;
+                using value_type = TT;
+                using difference_type = std::ptrdiff_t;
+                using pointer = TT*;
+                using reference = TT&;
+
+            private:
                 This& list;
                 intptr_t i;
 


### PR DESCRIPTION
## Summary
This PR updates the project's CMake minimum version requirement and modernizes the iterator implementation in the List class to follow C++17 standards.

## Key Changes
- **CMake**: Bumped minimum required version from 3.1 to 3.5 to support modern CMake features
- **Iterator Implementation**: Refactored `generic_iterator` class to use explicit type aliases instead of inheriting from `std::iterator`
  - Replaced inheritance from `std::iterator<std::input_iterator_tag, TT>` with explicit member type aliases
  - Added public type definitions: `iterator_category`, `value_type`, `difference_type`, `pointer`, and `reference`
  - Moved private members (`list` and `i`) to explicit `private:` section for clarity

## Implementation Details
The iterator modernization follows the C++17 deprecation of `std::iterator` base class. By explicitly defining the required type aliases as public members, the iterator remains compatible with standard library algorithms while being forward-compatible with future C++ standards. This approach is more explicit and provides better code clarity regarding the iterator's interface.